### PR TITLE
let beanfactory extends DefaultSingletonBeanRegistry

### DIFF
--- a/.idea/Minis.iml
+++ b/.idea/Minis.iml
@@ -4,8 +4,10 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="lib" level="project" />
   </component>
 </module>

--- a/.idea/libraries/lib.xml
+++ b/.idea/libraries/lib.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+  <library name="lib">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/lib" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+    <jarDirectory url="file://$PROJECT_DIR$/lib" recursive="false" />
+  </library>
+</component>

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ We plan to implement IoC,MVC,JDBCTemplate and AOP from scratch.
 IoC is the core of Minis. We will use a bean factory to manage all required beans.
 
 Modified in local IntelliJ IDEA.
+
+Use DefaultSingletonBeanRegistry to maintain beans as a repository. 
+Modify beanfactory to just provide getBean(),defined as below:
+  public class SimpleBeanFactory extends DefaultSingletonBeanRegistry implements BeanFactory
+  
+When ClassPathXmlApplicationContext is instantiated, no bean instance will be created.
+the action to create a real bean instance is postponed to getBean() method.
+

--- a/src/com/minis/beans/BeanFactory.java
+++ b/src/com/minis/beans/BeanFactory.java
@@ -1,7 +1,8 @@
 package com.minis.beans;
 
 public interface BeanFactory {
-	Object getBean(String beanName) throws NoSuchBeanDefinitionException;
-	void registerBeanDefinition(BeanDefinition bd);
+    Object getBean(String name) throws BeansException;
+	boolean containsBean(String name);
+	void registerBean(String beanName, Object obj);
 
 }

--- a/src/com/minis/beans/BeansException.java
+++ b/src/com/minis/beans/BeansException.java
@@ -1,0 +1,7 @@
+package com.minis.beans;
+
+public class BeansException extends Exception {
+	public BeansException(String msg) {
+		super(msg);
+	}
+}

--- a/src/com/minis/beans/DefaultSingletonBeanRegistry.java
+++ b/src/com/minis/beans/DefaultSingletonBeanRegistry.java
@@ -1,0 +1,43 @@
+package com.minis.beans;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DefaultSingletonBeanRegistry implements SingletonBeanRegistry {
+    protected List<String> beanNames=new ArrayList<>();
+    protected Map<String, Object> singletons =new ConcurrentHashMap<>(256);
+
+	@Override
+	public void registerSingleton(String beanName, Object singletonObject) {
+		synchronized(this.singletons) {
+	    	this.singletons.put(beanName, singletonObject);
+	    	this.beanNames.add(beanName);
+		}
+	}
+
+	@Override
+	public Object getSingleton(String beanName) {
+		return this.singletons.get(beanName);
+	}
+
+	@Override
+	public boolean containsSingleton(String beanName) {
+		return this.singletons.containsKey(beanName);
+	}
+
+	@Override
+	public String[] getSingletonNames() {
+		return (String[]) this.beanNames.toArray();
+	}
+	
+	protected void removeSingleton(String beanName) {
+	    synchronized (this.singletons) {
+		    this.singletons.remove(beanName);
+		    this.beanNames.remove(beanName);
+	    }
+	}
+
+}

--- a/src/com/minis/beans/SingletonBeanRegistry.java
+++ b/src/com/minis/beans/SingletonBeanRegistry.java
@@ -1,0 +1,12 @@
+package com.minis.beans;
+
+public interface SingletonBeanRegistry {
+    void registerSingleton(String beanName, Object singletonObject);
+
+    Object getSingleton(String beanName);
+
+    boolean containsSingleton(String beanName);
+
+    String[] getSingletonNames();
+
+}

--- a/src/com/minis/beans/XmlBeanDefinitionReader.java
+++ b/src/com/minis/beans/XmlBeanDefinitionReader.java
@@ -10,8 +10,8 @@ import org.dom4j.io.SAXReader;
 import com.minis.core.Resource;
 
 public class XmlBeanDefinitionReader {
-	BeanFactory bf;
-	public XmlBeanDefinitionReader(BeanFactory bf) {
+	SimpleBeanFactory bf;
+	public XmlBeanDefinitionReader(SimpleBeanFactory bf) {
 		this.bf = bf;
 	}
 	public void loadBeanDefinitions(Resource res) {

--- a/src/com/minis/context/ApplicationEvent.java
+++ b/src/com/minis/context/ApplicationEvent.java
@@ -1,0 +1,14 @@
+package com.minis.context;
+
+import java.util.EventObject;
+
+public class ApplicationEvent extends EventObject {
+
+	private static final long serialVersionUID = 1L;
+
+	public ApplicationEvent(Object arg0) {
+		super(arg0);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/src/com/minis/context/ApplicationEventPublisher.java
+++ b/src/com/minis/context/ApplicationEventPublisher.java
@@ -1,0 +1,5 @@
+package com.minis.context;
+
+public interface ApplicationEventPublisher {
+	void publishEvent(ApplicationEvent event);
+}

--- a/src/com/minis/context/ClassPathXmlApplicationContext.java
+++ b/src/com/minis/context/ClassPathXmlApplicationContext.java
@@ -12,33 +12,41 @@ import org.dom4j.io.SAXReader;
 
 import com.minis.beans.BeanDefinition;
 import com.minis.beans.BeanFactory;
+import com.minis.beans.BeansException;
 import com.minis.beans.NoSuchBeanDefinitionException;
 import com.minis.beans.SimpleBeanFactory;
 import com.minis.beans.XmlBeanDefinitionReader;
 import com.minis.core.ClassPathXmlResource;
 import com.minis.core.Resource;
 
-public class ClassPathXmlApplicationContext implements BeanFactory{
+public class ClassPathXmlApplicationContext implements BeanFactory,ApplicationEventPublisher{
 	BeanFactory beanFactory;
 	
     public ClassPathXmlApplicationContext(String fileName){
     	Resource res = new ClassPathXmlResource(fileName);
-    	BeanFactory bf = new SimpleBeanFactory();
+    	SimpleBeanFactory bf = new SimpleBeanFactory();
         XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(bf);
         reader.loadBeanDefinitions(res);
         this.beanFactory = bf;
     }
     
 	@Override
-	public Object getBean(String beanName) throws NoSuchBeanDefinitionException {
+	public Object getBean(String beanName) throws BeansException {
 		return this.beanFactory.getBean(beanName);
 	}
 
 	@Override
-	public void registerBeanDefinition(BeanDefinition bd) {
-		this.beanFactory.registerBeanDefinition(bd);
-		
+	public boolean containsBean(String name) {
+		return this.beanFactory.containsBean(name);
 	}
 
+	@Override
+	public void registerBean(String beanName, Object obj) {
+		this.beanFactory.registerBean(beanName, obj);		
+	}
+
+	@Override
+	public void publishEvent(ApplicationEvent event) {
+	}
     
 }

--- a/src/com/minis/test/AServiceImpl.java
+++ b/src/com/minis/test/AServiceImpl.java
@@ -5,7 +5,7 @@ public class AServiceImpl implements AService {
 	@Override
 	public void sayHello() {
 		// TODO Auto-generated method stub
-		System.out.println("a service 1 say hello.");
+		System.out.println("a skilled service 1 say hello.");
 
 	}
 

--- a/src/com/minis/test/Test1.java
+++ b/src/com/minis/test/Test1.java
@@ -1,11 +1,20 @@
 package com.minis.test;
 
+import com.minis.beans.BeansException;
+import com.minis.beans.NoSuchBeanDefinitionException;
+import com.minis.context.ClassPathXmlApplicationContext;
+
 public class Test1 {
 
 	public static void main(String[] args) {
 		ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("beans.xml");
-	    AService aService=(AService)ctx.getBean("aservice");
-	    aService.sayHello();
+	    AService aService;
+		try {
+			aService = (AService)ctx.getBean("aservice");
+		    aService.sayHello();
+		} catch (BeansException e) {
+			e.printStackTrace();
+		}
 	}
 
 }


### PR DESCRIPTION
Use DefaultSingletonBeanRegistry to maintain beans as a repository. 
Modify beanfactory to just provide getBean(),defined as below:
  public class SimpleBeanFactory extends DefaultSingletonBeanRegistry implements BeanFactory
  
When ClassPathXmlApplicationContext is instantiated, no bean instance will be created.
the action to create a real bean instance is postponed to getBean() method.