### PR TITLE
Ioc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,3 @@ We plan to implement IoC,MVC,JDBCTemplate and AOP from scratch.
 IoC is the core of Minis. We will use a bean factory to manage all required beans.
 
 Modified in local IntelliJ IDEA.
-
-Use DefaultSingletonBeanRegistry to maintain beans as a repository. 
-Modify beanfactory to just provide getBean(),defined as below:
-  public class SimpleBeanFactory extends DefaultSingletonBeanRegistry implements BeanFactory
-  
-When ClassPathXmlApplicationContext is instantiated, no bean instance will be created.
-the action to create a real bean instance is postponed to getBean() method.
-

--- a/src/com/minis/beans/ArgumentValue.java
+++ b/src/com/minis/beans/ArgumentValue.java
@@ -1,0 +1,43 @@
+package com.minis.beans;
+
+public class ArgumentValue {
+		private Object value;
+		private String type;
+		private String name;
+
+		public ArgumentValue(Object value, String type) {
+			this.value = value;
+			this.type = type;
+		}
+		public ArgumentValue(Object value, String type, String name) {
+			this.value = value;
+			this.type = type;
+			this.name = name;
+		}
+
+		public void setValue(Object value) {
+			this.value = value;
+		}
+
+		public Object getValue() {
+			return this.value;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		public String getType() {
+			return this.type;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+	}
+

--- a/src/com/minis/beans/ArgumentValues.java
+++ b/src/com/minis/beans/ArgumentValues.java
@@ -1,0 +1,70 @@
+package com.minis.beans;
+
+	import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+	import java.util.LinkedHashMap;
+	import java.util.LinkedList;
+	import java.util.List;
+	import java.util.Map;
+	import java.util.Set;
+
+	public class ArgumentValues {
+		private final Map<Integer, ArgumentValue> indexedArgumentValues = new HashMap<>(0);
+		private final List<ArgumentValue> genericArgumentValues = new LinkedList<ArgumentValue>();
+
+		public ArgumentValues() {
+		}
+
+		private void addArgumentValue(Integer key, ArgumentValue newValue) {
+			this.indexedArgumentValues.put(key, newValue);
+		}
+
+		public boolean hasIndexedArgumentValue(int index) {
+			return this.indexedArgumentValues.containsKey(index);
+		}
+
+
+		public ArgumentValue getIndexedArgumentValue(int index) {
+			ArgumentValue valueHolder = this.indexedArgumentValues.get(index);
+			return valueHolder;
+		}
+
+		public void addGenericArgumentValue(Object value, String type) {
+			this.genericArgumentValues.add(new ArgumentValue(value, type));
+		}
+
+
+		private void addGenericArgumentValue(ArgumentValue newValue) {
+			if (newValue.getName() != null) {
+				for (Iterator<ArgumentValue> it = this.genericArgumentValues.iterator(); it.hasNext();) {
+					ArgumentValue currentValue = it.next();
+					if (newValue.getName().equals(currentValue.getName())) {
+						it.remove();
+					}
+				}
+			}
+			this.genericArgumentValues.add(newValue);
+		}
+
+		public ArgumentValue getGenericArgumentValue(String requiredName) {
+			for (ArgumentValue valueHolder : this.genericArgumentValues) {
+				if (valueHolder.getName() != null &&
+						(requiredName == null || !valueHolder.getName().equals(requiredName))) {
+					continue;
+				}
+				return valueHolder;
+			}
+			return null;
+		}
+
+
+		public int getArgumentCount() {
+			return (this.genericArgumentValues.size());
+		}
+
+
+		public boolean isEmpty() {
+			return (this.genericArgumentValues.isEmpty());
+		}
+	}

--- a/src/com/minis/beans/BeanDefinition.java
+++ b/src/com/minis/beans/BeanDefinition.java
@@ -1,8 +1,20 @@
 package com.minis.beans;
 
 public class BeanDefinition {
+	String SCOPE_SINGLETON = "singleton";
+	String SCOPE_PROTOTYPE = "prototype";
+	
+	private boolean lazyInit = false;
+	private String[] dependsOn;
+	private ArgumentValues constructorArgumentValues;
+
+	private PropertyValues propertyValues;
+	private String initMethodName;
+	
+	private volatile Object beanClass;
     private String id;
     private String className;
+    private String scope=SCOPE_SINGLETON;
     
     public String getId() {
         return id;
@@ -21,4 +33,77 @@ public class BeanDefinition {
         this.id = id;
         this.className = className;
     }
+    
+	public boolean hasBeanClass() {
+		return (this.beanClass instanceof Class);
+	}
+	
+	public void setBeanClass(Class<?> beanClass) {
+		this.beanClass = beanClass;
+	}
+	
+	public Class<?> getBeanClass(){
+
+		return (Class<?>) this.beanClass;
+	}
+	
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public String getScope() {
+		return this.scope;
+	}
+	
+	public boolean isSingleton() {
+		return SCOPE_SINGLETON.equals(scope);
+	}
+
+	public boolean isPrototype() {
+		return SCOPE_PROTOTYPE.equals(scope);
+	}
+	
+	public void setLazyInit(boolean lazyInit) {
+		this.lazyInit = lazyInit;
+	}
+
+	public boolean isLazyInit() {
+		return this.lazyInit;
+	}
+	
+	public void setDependsOn(String... dependsOn) {
+		this.dependsOn = dependsOn;
+	}
+
+	public String[] getDependsOn() {
+		return this.dependsOn;
+	}
+	
+	public void setConstructorArgumentValues(ArgumentValues constructorArgumentValues) {
+		this.constructorArgumentValues =
+				(constructorArgumentValues != null ? constructorArgumentValues : new ArgumentValues());
+	}
+
+	public ArgumentValues getConstructorArgumentValues() {
+		return this.constructorArgumentValues;
+	}
+
+	public boolean hasConstructorArgumentValues() {
+		return !this.constructorArgumentValues.isEmpty();
+	}
+	public void setPropertyValues(PropertyValues propertyValues) {
+		this.propertyValues = (propertyValues != null ? propertyValues : new PropertyValues());
+	}
+
+	public PropertyValues getPropertyValues() {
+		return this.propertyValues;
+	}
+	public void setInitMethodName(String initMethodName) {
+		this.initMethodName = initMethodName;
+	}
+
+	public String getInitMethodName() {
+		return this.initMethodName;
+	}
+    
 }

--- a/src/com/minis/beans/BeanDefinitionRegistry.java
+++ b/src/com/minis/beans/BeanDefinitionRegistry.java
@@ -1,0 +1,8 @@
+package com.minis.beans;
+
+public interface BeanDefinitionRegistry {
+	void registerBeanDefinition(String name, BeanDefinition bd);
+	void removeBeanDefinition(String name);
+	BeanDefinition getBeanDefinition(String name);
+	boolean containsBeanDefinition(String name);
+}

--- a/src/com/minis/beans/BeanFactory.java
+++ b/src/com/minis/beans/BeanFactory.java
@@ -3,6 +3,9 @@ package com.minis.beans;
 public interface BeanFactory {
     Object getBean(String name) throws BeansException;
 	boolean containsBean(String name);
-	void registerBean(String beanName, Object obj);
+	//void registerBean(String beanName, Object obj);
+	boolean isSingleton(String name);
+	boolean isPrototype(String name);
+	Class<?> getType(String name);
 
 }

--- a/src/com/minis/beans/DefaultSingletonBeanRegistry.java
+++ b/src/com/minis/beans/DefaultSingletonBeanRegistry.java
@@ -4,28 +4,31 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultSingletonBeanRegistry implements SingletonBeanRegistry {
     protected List<String> beanNames=new ArrayList<>();
-    protected Map<String, Object> singletons =new ConcurrentHashMap<>(256);
-
+    protected Map<String, Object> singletonObjects =new ConcurrentHashMap<>(256);
+    protected Map<String,Set<String>> dependentBeanMap = new ConcurrentHashMap<>(64);
+    protected Map<String,Set<String>> dependenciesForBeanMap = new ConcurrentHashMap<>(64);
+    
 	@Override
 	public void registerSingleton(String beanName, Object singletonObject) {
-		synchronized(this.singletons) {
-	    	this.singletons.put(beanName, singletonObject);
+		synchronized(this.singletonObjects) {
+	    	this.singletonObjects.put(beanName, singletonObject);
 	    	this.beanNames.add(beanName);
 		}
 	}
 
 	@Override
 	public Object getSingleton(String beanName) {
-		return this.singletons.get(beanName);
+		return this.singletonObjects.get(beanName);
 	}
 
 	@Override
 	public boolean containsSingleton(String beanName) {
-		return this.singletons.containsKey(beanName);
+		return this.singletonObjects.containsKey(beanName);
 	}
 
 	@Override
@@ -34,10 +37,22 @@ public class DefaultSingletonBeanRegistry implements SingletonBeanRegistry {
 	}
 	
 	protected void removeSingleton(String beanName) {
-	    synchronized (this.singletons) {
-		    this.singletons.remove(beanName);
+	    synchronized (this.singletonObjects) {
+		    this.singletonObjects.remove(beanName);
 		    this.beanNames.remove(beanName);
 	    }
 	}
-
-}
+	
+	protected void registerDependentBean(String beanName, String dependentBeanName) {
+		
+	}
+	
+	protected boolean hasDependentBean(String beanName) {
+		return false;
+	}
+	protected String[] getDependentBeans(String beanName) {
+		return null;
+	}
+	protected String[] getDependenciesForBean(String beanName) {
+		return null;
+	}}

--- a/src/com/minis/beans/PropertyValue.java
+++ b/src/com/minis/beans/PropertyValue.java
@@ -1,0 +1,23 @@
+package com.minis.beans;
+
+public class PropertyValue{
+
+	private final String name;
+
+	private final Object value;
+
+	public PropertyValue(String name, Object value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public Object getValue() {
+		return this.value;
+	}
+
+}
+

--- a/src/com/minis/beans/PropertyValues.java
+++ b/src/com/minis/beans/PropertyValues.java
@@ -1,0 +1,71 @@
+package com.minis.beans;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+public class PropertyValues{
+	private final List<PropertyValue> propertyValueList;
+
+	public PropertyValues() {
+		this.propertyValueList = new ArrayList<PropertyValue>(0);
+	}
+
+	public List<PropertyValue> getPropertyValueList() {
+		return this.propertyValueList;
+	}
+
+	public int size() {
+		return this.propertyValueList.size();
+	}
+
+	public void addPropertyValue(PropertyValue pv) {
+		this.propertyValueList.add(pv);
+	}
+
+	public void addPropertyValue(String propertyName, Object propertyValue) {
+		addPropertyValue(new PropertyValue(propertyName, propertyValue));
+	}
+
+	public void removePropertyValue(PropertyValue pv) {
+		this.propertyValueList.remove(pv);
+	}
+
+	public void removePropertyValue(String propertyName) {
+		this.propertyValueList.remove(getPropertyValue(propertyName));
+	}
+
+
+	public PropertyValue[] getPropertyValues() {
+		return this.propertyValueList.toArray(new PropertyValue[this.propertyValueList.size()]);
+	}
+
+	public PropertyValue getPropertyValue(String propertyName) {
+		for (PropertyValue pv : this.propertyValueList) {
+			if (pv.getName().equals(propertyName)) {
+				return pv;
+			}
+		}
+		return null;
+	}
+
+	public Object get(String propertyName) {
+		PropertyValue pv = getPropertyValue(propertyName);
+		return (pv != null ? pv.getValue() : null);
+	}
+
+	public boolean contains(String propertyName) {
+		return (getPropertyValue(propertyName) != null);
+	}
+
+	public boolean isEmpty() {
+		return this.propertyValueList.isEmpty();
+	}
+
+
+}
+

--- a/src/com/minis/beans/SimpleBeanFactory.java
+++ b/src/com/minis/beans/SimpleBeanFactory.java
@@ -6,8 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class SimpleBeanFactory extends DefaultSingletonBeanRegistry implements BeanFactory{
-    private Map<String,BeanDefinition> beanDefinitions=new ConcurrentHashMap<>(256);
+public class SimpleBeanFactory extends DefaultSingletonBeanRegistry implements BeanFactory,BeanDefinitionRegistry{
+    private Map<String,BeanDefinition> beanDefinitionMap=new ConcurrentHashMap<>(256);
+    private List<String> beanDefinitionNames=new ArrayList<>();
 
     public SimpleBeanFactory() {
     }
@@ -15,39 +16,86 @@ public class SimpleBeanFactory extends DefaultSingletonBeanRegistry implements B
     public Object getBean(String beanName) throws BeansException{
         Object singleton = this.getSingleton(beanName);
         if (singleton == null) {
-        		BeanDefinition bd = beanDefinitions.get(beanName);
-        		if (bd == null) {
-        			throw new BeansException("no bean");
-        		}
-        		try {
-            		singleton=Class.forName(bd.getClassName()).newInstance();
-				} catch (InstantiationException e) {
-					e.printStackTrace();
-				} catch (IllegalAccessException e) {
-					e.printStackTrace();
-				} catch (ClassNotFoundException e) {
-					e.printStackTrace();
-				}
-				this.registerSingleton(beanName, singleton);
+        		BeanDefinition bd = beanDefinitionMap.get(beanName);
+            	singleton=createBean(bd);
+				this.registerBean(beanName, singleton);
         }
         if (singleton == null) {
         	throw new BeansException("bean is null.");
         }
         return singleton;
     }
-    public void registerBeanDefinition(BeanDefinition bd){
-    	this.beanDefinitions.put(bd.getId(),bd);
-    }
-
 	@Override
 	public boolean containsBean(String name) {
 		return containsSingleton(name);
 	}
 
-	@Override
 	public void registerBean(String beanName, Object obj) {
 		this.registerSingleton(beanName, obj);
 		
+	}
+
+	@Override
+	public void registerBeanDefinition(String name, BeanDefinition bd) {
+    	this.beanDefinitionMap.put(name,bd);
+    	this.beanDefinitionNames.add(name);
+    	if (!bd.isLazyInit()) {
+        	try {
+				getBean(name);
+			} catch (BeansException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+    	}
+	}
+
+	@Override
+	public void removeBeanDefinition(String name) {
+		this.beanDefinitionMap.remove(name);
+		this.beanDefinitionNames.remove(name);
+		this.removeSingleton(name);
+		
+	}
+
+	@Override
+	public BeanDefinition getBeanDefinition(String name) {
+		return this.beanDefinitionMap.get(name);
+	}
+
+	@Override
+	public boolean containsBeanDefinition(String name) {
+		return this.beanDefinitionMap.containsKey(name);
+	}
+
+	@Override
+	public boolean isSingleton(String name) {
+		return this.beanDefinitionMap.get(name).isSingleton();
+	}
+
+	@Override
+	public boolean isPrototype(String name) {
+		return this.beanDefinitionMap.get(name).isPrototype();
+	}
+
+	@Override
+	public Class<?> getType(String name) {
+		return this.beanDefinitionMap.get(name).getClass();
+	}
+	
+	private Object createBean(BeanDefinition bd) {
+		Object obj = null;
+
+		try {
+    		obj = Class.forName(bd.getClassName()).newInstance();
+		} catch (InstantiationException e) {
+			e.printStackTrace();
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+		}
+		return obj;
+
 	}
     
 }

--- a/src/com/minis/beans/XmlBeanDefinitionReader.java
+++ b/src/com/minis/beans/XmlBeanDefinitionReader.java
@@ -20,7 +20,7 @@ public class XmlBeanDefinitionReader {
             String beanID=element.attributeValue("id");
             String beanClassName=element.attributeValue("class");
             BeanDefinition beanDefinition=new BeanDefinition(beanID,beanClassName);
-            this.bf.registerBeanDefinition(beanDefinition);
+            this.bf.registerBeanDefinition(beanID,beanDefinition);
         }
 		
 	}

--- a/src/com/minis/context/ClassPathXmlApplicationContext.java
+++ b/src/com/minis/context/ClassPathXmlApplicationContext.java
@@ -20,7 +20,7 @@ import com.minis.core.ClassPathXmlResource;
 import com.minis.core.Resource;
 
 public class ClassPathXmlApplicationContext implements BeanFactory,ApplicationEventPublisher{
-	BeanFactory beanFactory;
+	SimpleBeanFactory beanFactory;
 	
     public ClassPathXmlApplicationContext(String fileName){
     	Resource res = new ClassPathXmlResource(fileName);
@@ -40,13 +40,30 @@ public class ClassPathXmlApplicationContext implements BeanFactory,ApplicationEv
 		return this.beanFactory.containsBean(name);
 	}
 
-	@Override
 	public void registerBean(String beanName, Object obj) {
 		this.beanFactory.registerBean(beanName, obj);		
 	}
 
 	@Override
 	public void publishEvent(ApplicationEvent event) {
+	}
+
+	@Override
+	public boolean isSingleton(String name) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isPrototype(String name) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public Class<?> getType(String name) {
+		// TODO Auto-generated method stub
+		return null;
 	}
     
 }

--- a/src/com/minis/test/AServiceImpl.java
+++ b/src/com/minis/test/AServiceImpl.java
@@ -4,8 +4,7 @@ public class AServiceImpl implements AService {
 
 	@Override
 	public void sayHello() {
-		// TODO Auto-generated method stub
-		System.out.println("a skilled service 1 say hello.");
+		System.out.println("a service 1 say hello.");
 
 	}
 


### PR DESCRIPTION
Use DefaultSingletonBeanRegistry to maintain beans as a repository. Modify beanfactory to just provide getBean(),defined as below: public class SimpleBeanFactory extends DefaultSingletonBeanRegistry implements BeanFactory
When ClassPathXmlApplicationContext is instantiated, no bean instance will be created. the action to create a real bean instance is postponed to getBean() method.
extends beandefinition to support more fields, mainly add ArgumentValues and PropertyValues.
A separate BeanDefinitionRegistry class is used to contain beandefintions.
modify BeanFactory as below:
	class SimpleBeanFactory extends DefaultSingletonBeanRegistry implements BeanFactory,BeanDefinitionRegistry